### PR TITLE
security: scrub /home/bryanchasko absolute paths from goose extension config

### DIFF
--- a/.goose/extensions/full.yaml
+++ b/.goose/extensions/full.yaml
@@ -27,7 +27,7 @@ extensions:
     enabled: true
     type: stdio
     name: github
-    cmd: /home/bryanchasko/code/heraldstack/heraldstack-mcp/launchers/core/github.sh
+    cmd: ${HOME}/code/heraldstack/heraldstack-mcp/launchers/core/github.sh
     args: []
     timeout: 300
 
@@ -37,7 +37,7 @@ extensions:
     enabled: true
     type: stdio
     name: context7
-    cmd: /home/bryanchasko/code/heraldstack/heraldstack-mcp/launchers/core/context7.sh
+    cmd: ${HOME}/code/heraldstack/heraldstack-mcp/launchers/core/context7.sh
     args: []
     timeout: 300
 


### PR DESCRIPTION
## summary

recon audit 2026-04-10 (heraldstack-infra gitleaks ruleset) flagged `/home/bryanchasko` absolute paths in `.goose/extensions/full.yaml` lines 30 and 40. public repo exposure of operator home path.

## change

replaced `/home/bryanchasko` with `${HOME}` in both `cmd:` fields:
- `github` extension launcher
- `context7` extension launcher

## verification

`grep -r '/home/bryanchasko' .` returns empty

## scope

this file only. normal commit, no history rewrite.